### PR TITLE
Create customDropETH.sol

### DIFF
--- a/contracts/customDropETH.sol
+++ b/contracts/customDropETH.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.6.0;
+
+contract DropETH {
+
+    function dropETH(uint256[] memory amounts, address payable[] memory recipients) public payable {
+        require(amounts.length == recipients.length);
+        require(amounts.length <= 50);
+
+        for (uint256 i = 0; i < amounts.length; i++) {
+	        for (uint256 j = 0; j < amounts.length; j++) {
+	            recipients[i].transfer(amounts[j]);
+	        }
+        }
+    }
+}

--- a/contracts/customDropETH.sol
+++ b/contracts/customDropETH.sol
@@ -1,15 +1,16 @@
 pragma solidity ^0.6.0;
 
-contract DropETH {
+contract DropETH { // transfer msg.sender ETH to recipients by weight  per attached drop amount w/ msg.
+    event ETHDropped(string indexed message);
 
-    function dropETH(uint256[] memory amounts, address payable[] memory recipients) public payable {
-        require(amounts.length == recipients.length);
-        require(amounts.length <= 50);
+    function dropETH(uint256[] memory weights, address payable[] memory recipients, string memory message) public payable {
+        require(weights.length == recipients.length);
 
-        for (uint256 i = 0; i < amounts.length; i++) {
-	        for (uint256 j = 0; j < amounts.length; j++) {
-	            recipients[i].transfer(amounts[j]);
-	        }
+        uint256 totalAmount = msg.value / 100;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            (bool success, ) = recipients[i].call.value(weights[i] * totalAmount)("");
+            require(success, "Transfer failed.");
         }
+        emit ETHDropped(message);
     }
 }


### PR DESCRIPTION
Instead of transferring specific amount of ETH to each recipient, the contract distributes ETH by weight, specified as an input to the dropETH function. 

Rinkeby testing:
2 recipients - https://rinkeby.etherscan.io/tx/0x2a37c0d555383a9abda2eeef091aa291558d9858c156cbaccc0397b0ba147fa7
4 recipients - https://rinkeby.etherscan.io/tx/0x3acff2bd00eb5afead11c0f166aa640ef238537e47d089186dcdfcc75b8d8406